### PR TITLE
Removed required field settings for image credit (I think)

### DIFF
--- a/stanford_image.field_group.inc
+++ b/stanford_image.field_group.inc
@@ -1346,7 +1346,6 @@ function stanford_image_field_group_info() {
     'format_settings' => array(
       'label' => 'Add/Edit Image',
       'instance_settings' => array(
-        'required_fields' => 1,
         'classes' => '',
         'description' => '',
       ),


### PR DESCRIPTION
I vote to remove Image Credit as a required field.  This is annoying for users who want to use Stanford Pages that don't happen to have any images. Image credit is required in UI even when image field is not there!  Thanks for your consideration. Peace, Love, and Drupal.
