### PR TITLE
SOE-1354: change max_resolution to 3200x3200

### DIFF
--- a/stanford_image.features.field_instance.inc
+++ b/stanford_image.features.field_instance.inc
@@ -885,7 +885,7 @@ function stanford_image_field_default_field_instances() {
       'file_directory' => '',
       'file_extensions' => 'png gif jpg jpeg',
       'max_filesize' => '',
-      'max_resolution' => '1200x1200',
+      'max_resolution' => '3200x3200',
       'min_resolution' => '',
       'title_field' => 0,
       'user_register_form' => FALSE,


### PR DESCRIPTION
@boznik,

This increases the max resolution that image field collections can upload. We're hoping for better resolution!